### PR TITLE
Change "Volume" slider name to "Master"

### DIFF
--- a/sounds.py
+++ b/sounds.py
@@ -196,7 +196,7 @@ class MasterVolume(Volume):
                  os.path.expanduser("~/.config/ambientsounds/sounds")]
 
     def __init__(self):
-        Volume.__init__(self, "Volume", 100)
+        Volume.__init__(self, "Master", 100)
 
         # Get the sounds
         self.sounds = []


### PR DESCRIPTION
This label makes more sense. All of the gui sliders are volume sliders, so the master slider should be named "Master" to avoid being unspecific.
